### PR TITLE
Optional different streaming url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:9-alpine
-LABEL maintainer "jf.arseneau@gmail.com"
+LABEL maintainer="jf.arseneau@gmail.com"
 
 COPY . /antennas
 WORKDIR "/antennas"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Antennas will look for three values inside a `config/config.yml` file. They are:
 #### Environment variables
 
 If you want to set environment variables instead of modifying the config.yml, you can do so. The environment variable names are the same than the config.yml, except capitalized. So, `TVHEADEND_URL` and `TUNER_COUNT`.
+Optionally, when you are hosting tvheadend and antennas in a private docker network, you can specify an URL where your tvheadend service and therefore the actual streams will be available in your network (e.g. the hostname and port of your host maschine)  
 
 ## Contributing
 

--- a/public/index.html
+++ b/public/index.html
@@ -52,6 +52,10 @@
             <td><a id="tvheadendUrl"></a></td>
           </tr>
           <tr>
+            <td>Public URL for Tvheadend streams</td>
+            <td><a id="tvheadendStreamUrl"></a></td>
+          </tr>
+          <tr>
             <td>URL for Antennas</td>
             <td><a id="antennasUrl"></a></td>
           </tr>

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1,31 +1,32 @@
 function fetch(url) {
-  return new Promise((resolve, reject) => {
-    const xhr = new XMLHttpRequest();
-    xhr.open("GET", url);
-    xhr.onload = () => resolve(xhr.responseText);
-    xhr.onerror = () => reject(xhr.statusText);
-    xhr.send();
-  });
+    return new Promise((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+        xhr.open("GET", url);
+        xhr.onload = () => resolve(xhr.responseText);
+        xhr.onerror = () => reject(xhr.statusText);
+        xhr.send();
+    });
 }
 
 function replace(elementId) {
-  return function(content) {
-    document.querySelector(elementId).innerHTML = content;
-  }
+    return function (content) {
+        document.querySelector(elementId).innerHTML = content;
+    }
 }
 
 function urlReplace(elementId) {
-  return function(content) {
-    document.querySelector(elementId).href = content;
-    document.querySelector(elementId).innerHTML = content;
-  }
+    return function (content) {
+        document.querySelector(elementId).href = content;
+        document.querySelector(elementId).innerHTML = content;
+    }
 }
 
 fetch('/antennas_config.json').then((result) => {
-  let config = JSON.parse(result);
-  urlReplace('#tvheadendUrl')(config.tvheadend_url);
-  urlReplace('#antennasUrl')(config.antennas_url);
-  replace('#tunerCount')(config.tuner_count);
-  replace('#status')(config.status);
+    let config = JSON.parse(result);
+    urlReplace('#tvheadendUrl')(config.tvheadend_url);
+    urlReplace('#tvheadendStreamUrl')(config.public_tvheadend_stream_url);
+    urlReplace('#antennasUrl')(config.antennas_url);
+    replace('#tunerCount')(config.tuner_count);
+    replace('#status')(config.status);
 });
 

--- a/src/config.js
+++ b/src/config.js
@@ -2,39 +2,43 @@ const yaml = require('js-yaml');
 const fs = require('fs');
 
 function parseTvheadendURI(uri) {
-  let splitURI = uri.split('@');
-  if (splitURI.length > 1) {
-    let password = splitURI[0].split(':')[2];
-    let username = splitURI[0].split(":")[1].substr(2);
-    let parsedURI = `${splitURI[0].split(":")[0]}://${splitURI[1]}`
-    return {
-      username: username,
-      password: password,
-      uri: parsedURI,
+    let splitURI = uri.split('@');
+    if (splitURI.length > 1) {
+        let password = splitURI[0].split(':')[2];
+        let username = splitURI[0].split(":")[1].substr(2);
+        let parsedURI = `${splitURI[0].split(":")[0]}://${splitURI[1]}`
+        return {
+            username: username,
+            password: password,
+            uri: parsedURI,
+        }
+    } else {
+        return {
+            username: null,
+            password: null,
+            uri: uri,
+        }
     }
-  } else {
-    return {
-      username: null,
-      password: null,
-      uri: uri,
-    }
-  }
 }
 
-module.exports = function() {
-  let config = yaml.safeLoad(fs.readFileSync('config/config.yml', 'utf8'));
-  tvheadendUrl = process.env.TVHEADEND_URL || config.tvheadend_url;
-  antennasUrl = process.env.ANTENNAS_URL || config.antennas_url;
-  tunerCount = process.env.TUNER_COUNT || config.tuner_count;
-  DeviceUuid = process.env.DEVICE_UUID || config.device_uuid;
-  let parsedTvheadendURI = parseTvheadendURI(tvheadendUrl);
-  return {
-    tvheadend_parsed_uri: parsedTvheadendURI.uri,
-    tvheadend_username: parsedTvheadendURI.username,
-    tvheadend_password: parsedTvheadendURI.password,
-    tvheadend_url: tvheadendUrl,
-    antennas_url: antennasUrl,
-    tuner_count: tunerCount,
-    device_uuid: DeviceUuid
-  }
+module.exports = function () {
+    let config = yaml.safeLoad(fs.readFileSync('config/config.yml', 'utf8'));
+    tvheadendUrl = process.env.TVHEADEND_URL || config.tvheadend_url;
+    publicTvheadendStreamUrl = process.env.PUBLIC_TVHEADEND_STREAM_URL || process.env.TVHEADEND_URL || config.tvheadend_url;
+    antennasUrl = process.env.ANTENNAS_URL || config.antennas_url;
+    tunerCount = parseInt(process.env.TUNER_COUNT) || config.tuner_count;
+    DeviceUuid = process.env.DEVICE_UUID || config.device_uuid;
+    let parsedTvheadendURI = parseTvheadendURI(tvheadendUrl);
+    let parsedPublicTvheadendStreamURI = parseTvheadendURI(publicTvheadendStreamUrl);
+    return {
+        tvheadend_parsed_uri: parsedTvheadendURI.uri,
+        public_tvheadend_parsed_stream_uri: parsedPublicTvheadendStreamURI.uri,
+        tvheadend_username: parsedTvheadendURI.username,
+        tvheadend_password: parsedTvheadendURI.password,
+        tvheadend_url: tvheadendUrl,
+        public_tvheadend_stream_url: publicTvheadendStreamUrl,
+        antennas_url: antennasUrl,
+        tuner_count: tunerCount,
+        device_uuid: DeviceUuid
+    }
 }

--- a/src/lineup.js
+++ b/src/lineup.js
@@ -2,21 +2,21 @@ const request = require('request-promise-native');
 const config = require('./config');
 const getAPIOptions = require('./api_options');
 
-module.exports = function() {
-  let options = getAPIOptions('/api/channel/grid?start=0&limit=999999', config().tvheadend_url);
-  return request(options).then(function(body) {
-    // TODO: Check if there's a Plex permission problem
-    let lineup = [];
-    for (let channel of body.entries) {
-      if (channel.enabled) {
-        lineup.push({
-          GuideNumber: String(channel.number),
-          GuideName: channel.name,
-          URL: `${config().tvheadend_parsed_uri}/stream/channel/${channel.uuid}`
-        })
-      }
-    }
+module.exports = function () {
+    let options = getAPIOptions('/api/channel/grid?start=0&limit=999999', config().tvheadend_url);
+    return request(options).then(function (body) {
+        // TODO: Check if there's a Plex permission problem
+        let lineup = [];
+        for (let channel of body.entries) {
+            if (channel.enabled) {
+                lineup.push({
+                    GuideNumber: String(channel.number),
+                    GuideName: channel.name,
+                    URL: `${config().public_tvheadend_parsed_stream_uri}/stream/channel/${channel.uuid}`
+                })
+            }
+        }
 
-    return lineup;
-  });
+        return lineup;
+    });
 }


### PR DESCRIPTION
In my setup, I am hosting tvheadend and antennas in a docker network. 
As Plex is not part of this network, I need different URLs for antennas for fetching the channels and for Plex for accessing the actuals streams.

Other than that, I fixed the TUNER_COUNT was not parsed as int from the environment variables, resulting in antennas delivering the tuner count as string, resulting in Plex interpreting it in 50 available tuners